### PR TITLE
Add Mediawiki Translate extension (REL1_42)

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -196,6 +196,11 @@ in {
                 sha256 = "0fl80l3xi4fl98msmbwdi8vzynaaa9r6lp37hpb7faxhpkzb9wxh";
               };
             SyntaxHighlightHaskellAlias = ../SyntaxHighlightHaskellAlias;
+            Translate = pkgs.fetchgit
+              { url = "https://gerrit.wikimedia.org/r/mediawiki/extensions/Translate";
+                rev = "2384f52a003a5b7efd2c1519575b7fd972788441";
+                sha256 = "sha256-/sj0wfcjVFFq1uCACAJOOkmeEL98AVBGUHWp76Ie2Fo=";
+              };
           };
 
           database = {


### PR DESCRIPTION
Add the Translate extension from Wikimedia Gerrit to support translation features. The extension is pinned to a specific revision from the REL1_42 branch. The sha256 hash corresponds to that revision's contents.