### PR TITLE
Fix TemplateStyles build failure by switching from fetchzip to fetchGit

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -196,6 +196,11 @@ in {
                 sha256 = "0fl80l3xi4fl98msmbwdi8vzynaaa9r6lp37hpb7faxhpkzb9wxh";
               };
             SyntaxHighlightHaskellAlias = ../SyntaxHighlightHaskellAlias;
+            Translate = pkgs.fetchgit
+              { url = "https://gerrit.wikimedia.org/r/mediawiki/extensions/Translate";
+                rev = "2384f52a003a5b7efd2c1519575b7fd972788441";
+                sha256 = "sha256-/sj0wfcjVFFq1uCACAJOOkmeEL98AVBGUHWp76Ie2Fo=";
+              };
           };
 
           database = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -179,11 +179,10 @@ in {
             #       cp -R . $out/
             #     '';
             #   };
-            TemplateStyles = pkgs.fetchzip {
-              name = "TemplateStyles";
-              url = "https://extdist.wmflabs.org/dist/extensions/TemplateStyles-REL1_44-8269659.tar.gz";
-              hash = "sha256-MI3J4O1CKgBtdbQMwvdNS3E8LA/n0RZXTOR7QxqM3qM=";
-            };
+            TemplateStyles = builtins.fetchGit
+              { url = "https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateStyles.git";
+                rev = "f7da7be4e6d1cd314b4980e16364bb68f8ad8c8e";
+              };
                     SpamBlacklist = null;
             TitleBlacklist = null;
             SimpleMathJax = builtins.fetchGit


### PR DESCRIPTION
I just tried building the VM, and like last time, a 404 error occurred. As mentioned in #60, we should have used the Git-based download method from the start.
