### PR TITLE
Updates, better dev tooling, and the return of TemplateStyles

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 hawiki-config
 result
 hawiki-vm.qcow2
+hawiki-state/secret.key

--- a/README.md
+++ b/README.md
@@ -14,26 +14,41 @@ There is a test vm setup in the nix flake. The test vm uses the environment vari
 
 You will need a dump of the db and to setup a test password in `${HAWIKI_STATE}/hawiki-pass`
 
+## Build the VM
+
 You can build the test vm with
 
 ```bash
 nixos-rebuild build-vm --flake .#hawiki-vm
 ```
 
+## Run (and stop) the VM
 You can start the vm with
 ```bash
 ./result/bin/run-hawiki-vm-vm
 ```
 
-To setup the db with the dump inside the vm
-```bash
-nixos-container root-login hawiki
-cat /var/lib/mediawiki/hawiki-dump.sql | mysql mediawiki
-exit
-nixos-container restart hawiki
-```
+To exit, press `C-a x`. That's the QEMU escape sequence.
 
-To cleanup the vm state
-```bash
-./result/bin/run-hawiki-vm-vm
-```
+## Use the dev wiki
+
+Log in as admin with the password you've placed in hawiki-pass.
+
+### Editing
+
+In order to edit pages, the admin user needs to have their email validated.
+
+1. Run the VM
+2. Inside the VM, enter the container with `nixos-container root-login hawiki`
+3. Get a timestamp with `date +%Y%m%d%H%M`
+4. Connect to the database with `mysql mediawiki`
+5. Run the sql:
+   ```
+   update user
+   set user_email = admin@example.com, user_email_authenticated = '$timestamp'
+   where user_name = 'Admin';
+   ```
+
+   Replace `$timestamp` with the output from step 3.
+
+Log out (of the wiki) and log in again for the change to take effect.

--- a/README.md
+++ b/README.md
@@ -12,34 +12,51 @@ For issues with the *content* of the wiki, just edit the wiki! 😃
 
 There is a test vm setup in the nix flake. The test vm uses the environment variable `$HAWIKI_STATE` to pass in the state dir for the test vm. You can either manually set the variable `export HAWIKI_STATE=/absolute/path/to/hawiki-state` or use `nix develop` to set it the `hawiki-state` directory in this project.
 
-You will need a dump of the db and to setup a test password in `${HAWIKI_STATE}/hawiki-pass`
+You will need a dump of the db and to setup a test password in `${HAWIKI_STATE}/initial-password`
+
+## Using `just`
+
+Commands below will use [just](https://just.systems/man/en/). If you can't or
+don't want to use just, look in ./justfile to see the expanded commands.
+
+just is included in the Nix shell.
 
 ## Build the VM
 
 You can build the test vm with
 
 ```bash
-nixos-rebuild build-vm --flake .#hawiki-vm
+just vm-build
 ```
 
 ## Run (and stop) the VM
 You can start the vm with
 ```bash
-./result/bin/run-hawiki-vm-vm
+just vm-run
 ```
 
-To exit, press `C-a x`. That's the QEMU escape sequence.
+Once inside the vm, press `C-a x`. That's the QEMU escape sequence.
+
+> [!NOTE]
+> You can't exit the vm by exiting the shell. Use the escape sequence instead.
+
+> [!TIP]
+> Tired of your test wiki data or stuck with unwanted persistent state? Delete
+> it with `just vm-clean` or `just vm-reallyclean`.
 
 ## Use the dev wiki
 
-Log in as admin with the password you've placed in hawiki-pass.
+Run the VM. Access the dev wiki at http://localhost:18888
+
+Log in as admin. The initial password in the default hawiki-state is
+`coolpassword`.
 
 ### Editing
 
 In order to edit pages, the admin user needs to have their email validated.
 
 1. Run the VM
-2. Inside the VM, enter the container with `nixos-container root-login hawiki`
+2. Inside the VM, enter the container with `machinectl shell hawiki`.
 3. Get a timestamp with `date +%Y%m%d%H%M`
 4. Connect to the database with `mysql mediawiki`
 5. Run the sql:

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762233356,
-        "narHash": "sha256-cGS3lLTYusbEP/IJIWGgnkzIl+FA5xDvtiHyjalGr4k=",
+        "lastModified": 1776067740,
+        "narHash": "sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca534a76c4afb2bdc07b681dbc11b453bab21af8",
+        "rev": "7e495b747b51f95ae15e74377c5ce1fe69c1765f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,37 @@
 {
   "nodes": {
+    "mediawikiPlugin_CollapsibleVector": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774759644,
+        "narHash": "sha256-J1+onyiHi6RvFnVCuGS9di1IPBqaYYR7+eS/mNCVEXo=",
+        "ref": "refs/heads/master",
+        "rev": "cc618aa97358a975f8b8023b235e0a1586d7e4dc",
+        "revCount": 371,
+        "type": "git",
+        "url": "https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector"
+      }
+    },
+    "mediawikiPlugin_SimpleMathJax": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768969987,
+        "narHash": "sha256-mmRe5TIQuUdJYVkDomwypy7qOkch3LE15DD3reEIQdY=",
+        "owner": "jmnote",
+        "repo": "SimpleMathJax",
+        "rev": "b53fdec1fd420744e00e34ddb2c2bd8b40b64005",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jmnote",
+        "repo": "SimpleMathJax",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1776067740,
@@ -18,6 +50,8 @@
     },
     "root": {
       "inputs": {
+        "mediawikiPlugin_CollapsibleVector": "mediawikiPlugin_CollapsibleVector",
+        "mediawikiPlugin_SimpleMathJax": "mediawikiPlugin_SimpleMathJax",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,32 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
 
-  outputs = { self, nixpkgs }:
+  inputs.mediawikiPlugin_CollapsibleVector = {
+    url = "git+https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector";
+    flake = false;
+  };
+  inputs.mediawikiPlugin_SimpleMathJax = {
+    url = "github:jmnote/SimpleMathJax";
+    flake = false;
+  };
+
+  outputs = inputs@{ self, nixpkgs, ... }:
   let
     systems = [ "x86_64-linux" "aarch64-linux" ];
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+    hawikiExtensions = {
+      CollapsibleVector = inputs.mediawikiPlugin_CollapsibleVector;
+      SimpleMathJax = inputs.mediawikiPlugin_SimpleMathJax;
+    };
   in {
-    nixosModules.hawiki = import ./nix/module.nix;
+    nixosModules.hawiki = { ... }: {
+      imports = [ ./nix/module.nix ];
+      services.hawiki.extensions = hawikiExtensions;
+    };
     nixosConfigurations.hawiki-vm = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
-      modules = [ ./nix/vm.nix ];
+      modules = [ self.nixosModules.hawiki ./nix/vm.nix ];
     };
     devShells = forAllSystems (pkgs: {
       default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
 
   outputs = { self, nixpkgs }:
   let

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
         shellHook = ''
           export HAWIKI_STATE=$(pwd)/hawiki-state/
         '';
+        packages = [ pkgs.just ];
       };
     });
   };

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
       system = "x86_64-linux";
       modules = [ self.nixosModules.hawiki ./nix/vm.nix ];
     };
+    checks.x86_64-linux.smoke = import ./nix/test.nix {
+      inherit self;
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    };
     devShells = forAllSystems (pkgs: {
       default = pkgs.mkShell {
         shellHook = ''

--- a/hawiki-state/initial-password
+++ b/hawiki-state/initial-password
@@ -1,0 +1,1 @@
+coolpassword

--- a/justfile
+++ b/justfile
@@ -11,3 +11,7 @@ vm-clean:
 # Also clean out the default state dir ./hawiki-state
 vm-reallyclean: vm-clean
     git clean -fdx hawiki-state
+
+# Runs a smoketest with a test vm
+test:
+    nix flake check

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+vm-build:
+    nixos-rebuild build-vm --flake .#hawiki-vm
+
+vm-run: vm-build
+    ./result/bin/run-hawiki-vm-vm
+
+# Remove the VM state file
+vm-clean:
+    rm hawiki-vm.qcow2
+
+# Also clean out the default state dir ./hawiki-state
+vm-reallyclean: vm-clean
+    git clean -fdx hawiki-state

--- a/nix/hawiki-container-config.nix
+++ b/nix/hawiki-container-config.nix
@@ -34,7 +34,7 @@ services.mediawiki = {
   url = "${if cfg.secure then "https" else "http"}://${cfg.url}";
   name = "HaskellWiki";
   passwordSender = "haskell-cafe@haskell.org";
-  passwordFile = "/var/lib/mediawiki/hawiki-pass";
+  passwordFile = "/var/lib/mediawiki/initial-password";
 
   nginx.hostName = cfg.url;
 

--- a/nix/hawiki-container-config.nix
+++ b/nix/hawiki-container-config.nix
@@ -111,44 +111,26 @@ services.mediawiki = {
 
   extensions = {
     Cite = null;
-    SyntaxHighlight_GeSHi = null;
-    Math = null;
-    Interwiki = null;
-    WikiEditor = null;
     CiteThisPage = null;
+    CollapsibleVector = null;
     ConfirmEdit = null;
     Gadgets = null;
     ImageMap = null;
     InputBox = null;
+    Interwiki = null;
+    Math = null;
     Nuke = null;
     ParserFunctions = null;
     Poem = null;
-
-    # FIXME TemplateStyles disabled because it's causing internal errors. Or,
-    # something is, and I'm guessing it's the new/changed version of
-    # TemplateStyles. Let's find out!
-    #
-    ## TODO: Remove this manual installation of TemplateStyles once MediaWiki is upgraded to 1.44 or later,
-    ## since the TemplateStyles extension will be bundled by default starting from that version.
-
-    #TemplateStyles = builtins.fetchGit {
-    #  url = "https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateStyles.git";
-    #  # Tag REL1_38, the last one I can find in the repo.
-    #  rev = "e0aa1fac05bcf580b539c1707d889dcfb4701cb0";
-    #};
+    SimpleMathJax = null;
     SpamBlacklist = null;
-    TitleBlacklist = null;
-    SimpleMathJax = builtins.fetchGit
-      { url = "https://github.com/jmnote/SimpleMathJax.git";
-        rev = "fab35e6ac66e1f5abd3c91a57719f8180dd346ef";
-      };
-    CollapsibleVector = pkgs.fetchgit
-      { url = "https://gerrit.wikimedia.org/r/mediawiki/extensions/CollapsibleVector";
-        rev = "3fddfb23f86061bbfafda6554b1d7c5f11edfcac";
-        sha256 = "0fl80l3xi4fl98msmbwdi8vzynaaa9r6lp37hpb7faxhpkzb9wxh";
-      };
+    # Should be an alias, but only shows up as "GeSHi" still.
+    SyntaxHighlight_GeSHi = null;
     SyntaxHighlightHaskellAlias = ../SyntaxHighlightHaskellAlias;
-  };
+    TemplateStyles = null;
+    TitleBlacklist = null;
+    WikiEditor = null;
+  } // cfg.extensions;
 
   database = {
     type = "mysql";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -21,6 +21,14 @@ in {
         type = types.bool;
         default = true;
       };
+      extensions = mkOption {
+        type = types.attrsOf (types.nullOr types.path);
+        default = {};
+        description = ''
+          Mediawiki extensions to override. These are merged (via //)
+          on top of the defaults in the container config.
+        '';
+      };
     };
   };
 

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,0 +1,27 @@
+{ self, pkgs }:
+
+pkgs.testers.nixosTest {
+  name = "hawiki-smoke";
+
+  nodes.machine = { ... }: {
+    imports = [ self.nixosModules.hawiki ];
+
+    services.hawiki = {
+      enable = true;
+      passFile = "/var/lib/hawiki/initial-password";
+      # Lets us curl the wiki from inside the vm.
+      url = "localhost:8081";
+      secure = false;
+    };
+
+    systemd.tmpfiles.rules = [
+      "f /var/lib/hawiki/initial-password 0644 root root - test-password"
+    ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("container@hawiki.service")
+    output = machine.succeed("curl --follow --fail-with-body http://localhost:8081/")
+    assert "HaskellWiki" in output, f"Expected 'HaskellWiki' in the output, got: {output:1000]}"
+  '';
+}

--- a/nix/vm.nix
+++ b/nix/vm.nix
@@ -37,13 +37,13 @@ in {
     cores = 1;
     graphics = false;
     sharedDirectories = {
-      brokerConfig = {
+      wikiState = {
         source = "$HAWIKI_STATE";
         target = stateDir;
       };
     };
     forwardPorts = [
-      { from = "host"; host.port = 18888; guest.port = 8081; }
+      { from = "host"; host.port = 18888; guest.port = 80; }
     ];
   };
 
@@ -59,7 +59,7 @@ in {
 
   services.hawiki = {
     enable = true;
-      passFile = "${stateDir}/hawiki-pass";
+      passFile = "${stateDir}/initial-password";
       url = "localhost:18888";
       secure = false;
   };

--- a/nix/vm.nix
+++ b/nix/vm.nix
@@ -3,7 +3,6 @@ let
   stateDir = "/var/lib/hawiki";
 in {
   imports = [
-    ./module.nix
     "${modulesPath}/virtualisation/qemu-vm.nix"
     "${modulesPath}/profiles/qemu-guest.nix"
   ];


### PR DESCRIPTION
Update the NixOS version used to build the wiki container, finally re-enable TemplateStyles plugin, and make it easier to test changes locally with the test VM.